### PR TITLE
Import p for props

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run dev
 
 ```typescript
 import {
-  Component, Prop, Watch, Lifecycle,
+  Component, Prop, Watch, Lifecycle, p
 } from 'av-ts'
 
 // vue options in `Component` decorator


### PR DESCRIPTION
I find we should import `p` to use, however, it was not mentioned on first example.
Could you update this?